### PR TITLE
fixed service files; disabled stdin for sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Steps to run:
 3. Run `sudo miracle-wifid --log-level trace --log-date-time` in a terminal.
 4. Run `sudo miracle-sinkctl -e run-vlc.sh --log-level trace --log-journal-level trace --log-date-time -- set-friendly-name VingMiracle` in a separate terminal.
 
+OR 
+
+1. Run `sudo systemctl start miracle-sink` to start
+2. Run `sudo systemctl stop miracle-wifid` to stop
 
 Now you should be able to cast your Windows 10/11 devices on Ving NUC.
 

--- a/src/ctl/ctl-cli.c
+++ b/src/ctl/ctl-cli.c
@@ -677,7 +677,8 @@ int cli_init(sd_bus *bus, const struct cli_cmd *cmds)
 		}
 	}
 
-	if (isatty(fileno(stdin))) {
+	if (1) {
+		/*
 		r = sd_event_add_io(cli_event,
 			    &cli_stdin,
 			    fileno(stdin),
@@ -687,7 +688,7 @@ int cli_init(sd_bus *bus, const struct cli_cmd *cmds)
 		if (r < 0) {
 			cli_vERR(r);
 			goto error;
-		}
+		}*/
 		cli_rl = true;
 
 		rl_erase_empty_line = 1;

--- a/src/wifi/wifid.c
+++ b/src/wifi/wifid.c
@@ -44,7 +44,7 @@
 #define STR(x) #x
 const char *interface_name = NULL;
 const char *config_methods = NULL;
-unsigned int arg_wpa_loglevel = LOG_DEBUG;
+unsigned int arg_wpa_loglevel = LOG_NOTICE;
 bool arg_wpa_syslog = false;
 bool use_dev = false;
 bool lazy_managed = false;

--- a/systemd/system/miracle-sink.service
+++ b/systemd/system/miracle-sink.service
@@ -5,6 +5,7 @@ After=miracle-wifid.service
 
 [Service]
 Type=simple
+ExecStartPre=/usr/bin/sleep 5
 ExecStart=/usr/bin/miracle-sinkctl -e run-vlc.sh --log-level debug --log-journal-level debug -- set-friendly-name VingMiracle
 #ExecStopPost=-/usr/bin/systemctl stop miracle-wifid.service
 User=root

--- a/systemd/system/miracle-sink.service
+++ b/systemd/system/miracle-sink.service
@@ -1,12 +1,12 @@
 [Unit]
 Description=Miraclecast sink on default link
-Before=network.target
 Requires=miracle-wifid.service
+After=miracle-wifid.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/miracle-sinkctl --log-level debug --log-journal-level debug -- set-friendly-name VingMiracle
-ExecStopPost=-/usr/bin/systemctl stop miracle-wifid.service
+ExecStart=/usr/bin/miracle-sinkctl -e run-vlc.sh --log-level debug --log-journal-level debug -- set-friendly-name VingMiracle
+#ExecStopPost=-/usr/bin/systemctl stop miracle-wifid.service
 User=root
 
 [Install]

--- a/systemd/system/miracle-wifid.service
+++ b/systemd/system/miracle-wifid.service
@@ -12,6 +12,7 @@ ExecStartPre=-/usr/bin/systemctl stop wpa_supplicant.service
 
 ExecStart=/usr/bin/miracle-wifid --log-level debug
 
+ExecStopPost=-/usr/bin/systemctl stop miracle-sink.service
 ExecStopPost=-/usr/bin/systemctl start wpa_supplicant.service
 ExecStopPost=-/usr/bin/systemctl start NetworkManager.service
 ExecStopPost=-/usr/bin/systemctl start ap.service


### PR DESCRIPTION
1. Commented out stdin registration and removed the terminal stdin restriction.
2. Fixed the service files. Start miracle-sink to start and stop miracle-wifid to stop.